### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /.cache
 /dist
-/package-lock.json


### PR DESCRIPTION
Correct me if I'm wrong, but I think `package-lock.json` is intended to be committed into your repo. I could be wrong, but I know similar technologies like Podfile.lock and Gemfile.lock are supposed to be committed to ensure builds are deterministic and are not subject to changes from package mantainers. 

IE: If I pin to use 2.3.0 or greater, and my local machine uses 2.3.0, but a maintainer releases 2.4.0 and subsequent contributors download 2.4.0 instead, causing unpredictable behavior.

https://docs.npmjs.com/configuring-npm/package-lock-json.html

This file is intended to be committed into source repositories, and serves various purposes:

Describe a single representation of a dependency tree such that teammates, deployments, and continuous integration are guaranteed to install exactly the same dependencies.

Provide a facility for users to “time-travel” to previous states of node_modules without having to commit the directory itself.

To facilitate greater visibility of tree changes through readable source control diffs.

And optimize the installation process by allowing npm to skip repeated metadata resolutions for previously-installed packages.
https://stackoverflow.com/questions/44206782/do-i-commit-the-package-lock-json-file-created-by-npm-5